### PR TITLE
Fix Chrome full screen support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kariudo/angular-fullscreen",
-  "version": "1.0.2",
+  "version": "1.0.2-talis.1",
   "description": "An AngularJS service and a directive to quickly use the HTML5 fullscreen API",
   "main": "src/angular-fullscreen.js",
   "files": [

--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -18,6 +18,17 @@
             emitter.$emit('FBFullscreen.change', serviceInstance.isEnabled());
          });
 
+         function enableWebkitFullScreen() {
+            if (isSafari51) {
+               // Safari 5.1 reports it supports keyboard input but doesn't work
+               element.webkitRequestFullscreen();
+            } else if (isKeyboardAvailbleOnFullScreen) {
+               element.webkitRequestFullscreen(isKeyboardAvailbleOnFullScreen);
+            } else {
+               element.webkitRequestFullscreen();
+            }
+         }
+
          var serviceInstance = {
             $on: angular.bind(emitter, emitter.$on),
             all: function() {
@@ -29,14 +40,7 @@
                } else if(element.mozRequestFullScreen) {
                   element.mozRequestFullScreen();
                } else if(element.webkitRequestFullscreen) {
-                  if (isSafari51) {
-                     // Safari 5.1 reports it supports keyboard input but doesn't work
-                     element.webkitRequestFullscreen();
-                  } else if (isKeyboardAvailbleOnFullScreen) {
-                     element.webkitRequestFullscreen(isKeyboardAvailbleOnFullScreen);
-                  } else {
-                     element.webkitRequestFullscreen();
-                  }
+                  enableWebkitFullScreen();
                } else if (element.msRequestFullscreen) {
                   element.msRequestFullscreen();
                }

--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -18,7 +18,7 @@
             emitter.$emit('FBFullscreen.change', serviceInstance.isEnabled());
          });
 
-         function enableWebkitFullScreen() {
+         function enableWebkitFullScreen(element) {
             if (isSafari51) {
                // Safari 5.1 reports it supports keyboard input but doesn't work
                element.webkitRequestFullscreen();
@@ -40,7 +40,7 @@
                } else if(element.mozRequestFullScreen) {
                   element.mozRequestFullScreen();
                } else if(element.webkitRequestFullscreen) {
-                  enableWebkitFullScreen();
+                  enableWebkitFullScreen(element);
                } else if (element.msRequestFullscreen) {
                   element.msRequestFullscreen();
                }

--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -8,6 +8,8 @@
          // ensure ALLOW_KEYBOARD_INPUT is available and enabled
          var isKeyboardAvailbleOnFullScreen = (typeof Element !== 'undefined' && 'ALLOW_KEYBOARD_INPUT' in Element) && Element.ALLOW_KEYBOARD_INPUT;
 
+         var isSafari51 = / Version\/5\.1(?:\.\d+)? Safari\//.test(navigator.userAgent);
+
          var emitter = $rootScope.$new();
 
          // listen event on document instead of element to avoid firefox limitation
@@ -27,7 +29,14 @@
                } else if(element.mozRequestFullScreen) {
                   element.mozRequestFullScreen();
                } else if(element.webkitRequestFullscreen) {
-                  element.webkitRequestFullscreen();
+                  if (isSafari51) {
+                     // Safari 5.1 reports it supports keyboard input but doesn't work
+                     element.webkitRequestFullscreen();
+                  } else if (isKeyboardAvailbleOnFullScreen) {
+                     element.webkitRequestFullscreen(isKeyboardAvailbleOnFullScreen);
+                  } else {
+                     element.webkitRequestFullscreen();
+                  }
                } else if (element.msRequestFullscreen) {
                   element.msRequestFullscreen();
                }


### PR DESCRIPTION
Recent versions of Chrome have started causing the following errors in our logs:-

```
TypeError: Failed to execute 'webkitRequestFullscreen' on 'Element': parameter 1 ('options') is not an object.
```

From digging around in this it seems that https://github.com/sindresorhus/screenfull.js/ has some better detection around the ALLOW_KEYBOARD_INPUT flag and the bug around Safari 5.1.  I've plucked those small changes out of there and into here. 

Tested locally with Chrome and my local Safari (12.1) and all well so far.
